### PR TITLE
squid:S1197 - Array designators should be on the type, not the variable

### DIFF
--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/VideoDetailsFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/VideoDetailsFragment.java
@@ -346,7 +346,7 @@ public class VideoDetailsFragment extends DetailsFragment
     }
 
     private void setupMovieListRow() {
-        String subcategories[] = {getString(R.string.related_movies)};
+        String[] subcategories = {getString(R.string.related_movies)};
 
         // Generating related video list.
         String category = mSelectedVideo.category;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AllApp.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AllApp.java
@@ -21,20 +21,20 @@ import java.util.List;
 public class AllApp extends LinearLayout implements View.OnClickListener {
 
     private Context mContext;
-    private ImageView appIcons[] = new ImageView[15];
-    private LinearLayout appItems[] = new LinearLayout[15];
-    private int iconIds[] = {R.id.app_icon0, R.id.app_icon1, R.id.app_icon2,
+    private ImageView[] appIcons = new ImageView[15];
+    private LinearLayout[] appItems = new LinearLayout[15];
+    private int[] iconIds = {R.id.app_icon0, R.id.app_icon1, R.id.app_icon2,
             R.id.app_icon3, R.id.app_icon4, R.id.app_icon5,
             R.id.app_icon6, R.id.app_icon7, R.id.app_icon8,
             R.id.app_icon9, R.id.app_icon10, R.id.app_icon11,
             R.id.app_icon12, R.id.app_icon13, R.id.app_icon14};
-    private TextView appNames[] = new TextView[15];
-    private int nameIds[] = {R.id.app_name0, R.id.app_name1, R.id.app_name2,
+    private TextView[] appNames = new TextView[15];
+    private int[] nameIds = {R.id.app_name0, R.id.app_name1, R.id.app_name2,
             R.id.app_name3, R.id.app_name4, R.id.app_name5,
             R.id.app_name6, R.id.app_name7, R.id.app_name8,
             R.id.app_name9, R.id.app_name10, R.id.app_name11,
             R.id.app_name12, R.id.app_name13, R.id.app_name14};
-    private int itemIds[] = {
+    private int[] itemIds = {
             R.id.app_item0, R.id.app_item1, R.id.app_item2,
             R.id.app_item3, R.id.app_item4, R.id.app_item5,
             R.id.app_item6, R.id.app_item7, R.id.app_item8,

--- a/jackyLauncher/src/main/java/com/jacky/launcher/main/MainActivity.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/main/MainActivity.java
@@ -48,7 +48,7 @@ public class MainActivity extends BaseTitleActivity implements View.OnClickListe
     private Context context;
     private FileCache fileCache;
     private String cacheDir;
-    private View mViews[];
+    private View[] mViews;
     private int mCurrentIndex = 0;
 
     public ViewPager.OnPageChangeListener pageListener = new ViewPager.OnPageChangeListener() {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileCache.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileCache.java
@@ -23,7 +23,7 @@ public class FileCache {
     }
 
     public ArrayList<File> getFile() {
-        File file[] = cacheDir.listFiles();
+        File[] file = cacheDir.listFiles();
         ArrayList<File> list = new ArrayList<>();
         for (int i = 0; i < file.length; i++) {
             list.add(file[i]);

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileUtils.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileUtils.java
@@ -290,7 +290,7 @@ public class FileUtils {
         while ((ch = in.read()) != -1) {
             out.write(ch);
         }
-        byte buffer[] = out.toByteArray();
+        byte[] buffer = out.toByteArray();
         out.close();
         return buffer;
     }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/ReadFileUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/ReadFileUtil.java
@@ -30,7 +30,7 @@ public class ReadFileUtil {
             startTime = System.currentTimeMillis();
             BufferedReader bufferReader = new BufferedReader(new InputStreamReader(mUrlConnection.getInputStream()));
             String line;
-            byte buffer[];
+            byte[] buffer;
             while (NetworkSpeedInfo.FILECANREAD && ((line = bufferReader.readLine()) != null) && fileLenth > NetworkSpeedInfo.FinishBytes) {
                 buffer = line.getBytes();
                 intervalTime = System.currentTimeMillis() - startTime;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1197 - Array designators should be on the type, not the variable

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197

Please let me know if you have any questions.

M-Ezzat