### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/SearchFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/SearchFragment.java
@@ -125,7 +125,11 @@ public class SearchFragment extends android.support.v17.leanback.app.SearchFragm
                         }
                         break;
                     // the rest includes various recognizer errors, see {@link RecognizerIntent}
+                    default:
+                        break;
                 }
+                break;
+            default:
                 break;
         }
     }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/LocalServiceFragment.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/LocalServiceFragment.java
@@ -97,6 +97,8 @@ public class LocalServiceFragment extends BaseFragment implements View.OnClickLi
                 break;
             case R.id.local_video:
                 break;
+            default:
+                break;
         }
     }
 }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/eliminateprocess/EliminateMainActivity.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/eliminateprocess/EliminateMainActivity.java
@@ -79,6 +79,8 @@ public class EliminateMainActivity extends Activity {
                 case PERCENT_CHANGE:
                     Allpercent.setText(allpercent + "%");
                     break;
+                default:
+                    break;
             }
         }
 

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/garbageclear/GarbageClear.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/garbageclear/GarbageClear.java
@@ -79,6 +79,8 @@ public class GarbageClear extends Activity {
                     RoundImg.setVisibility(View.GONE);
                     dialog_img.setImageResource(R.drawable.finish_clear);
                     break;
+                default:
+                    break;
             }
         }
 

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingCustom.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingCustom.java
@@ -80,6 +80,8 @@ public class SettingCustom extends Activity implements View.OnClickListener {
                 i.setClass(context, SpeedTestActivity.class);
                 startActivity(i);
                 break;
+            default:
+                break;
         }
     }
 }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingFragment.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingFragment.java
@@ -160,6 +160,8 @@ public class SettingFragment extends BaseFragment implements
                 JumpIntent = new Intent(context, SpeedTestActivity.class);
                 startActivity(JumpIntent);
                 break;
+            default:
+                break;
         }
     }
 }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/speedtest/SpeedTestActivity.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/speedtest/SpeedTestActivity.java
@@ -91,6 +91,8 @@ public class SpeedTestActivity extends Activity implements OnClickListener {
                     THREADCANRUN = false;
                     NetworkSpeedInfo.FILECANREAD = false;
                     break;
+                default:
+                    break;
             }
         }
 
@@ -193,6 +195,8 @@ public class SpeedTestActivity extends Activity implements OnClickListener {
                 DidNotStartLayout.setVisibility(View.VISIBLE);
                 StartAgainLayout.setVisibility(View.GONE);
                 InStartLayout.setVisibility(View.GONE);
+                break;
+            default:
                 break;
         }
     }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/wifi/WifiActivity.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/wifi/WifiActivity.java
@@ -130,6 +130,9 @@ public class WifiActivity extends Activity implements OnClickListener,OnItemClic
 		    		Toast.makeText(WifiActivity.this, "连接成功", Toast.LENGTH_SHORT).show();
 		    	}
 				break;
+			default:
+				break;
+			
 			}
 			 super.handleMessage(msg);
 		}

--- a/jackyLauncher/src/main/java/com/jacky/launcher/main/MainActivity.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/main/MainActivity.java
@@ -83,6 +83,8 @@ public class MainActivity extends BaseTitleActivity implements View.OnClickListe
                     setting.setSelected(false);
                     app.setSelected(true);
                     break;
+                default:
+                    break;
             }
         }
     };
@@ -197,6 +199,8 @@ public class MainActivity extends BaseTitleActivity implements View.OnClickListe
             case R.id.main_title_app:
                 currentIndex = 4;
                 mViewPager.setCurrentItem(2);
+                break;
+            default:
                 break;
         }
     }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusedRelativeLayout.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusedRelativeLayout.java
@@ -330,6 +330,8 @@ public class FocusedRelativeLayout extends RelativeLayout implements FocusedBase
                     break;
                 case 19:
                     localNodeInfo2.fromDown = ((View) v);
+                default:
+                    break;
             }
             boolean bool = true;
             if ((localObject2 instanceof ScalePostionInterface)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat