### PR TITLE
squid:S1068 - Unused private fields should be removed

### DIFF
--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/Bluetooth.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/Bluetooth.java
@@ -40,7 +40,6 @@ import java.util.Set;
 public class Bluetooth extends Activity implements View.OnClickListener {
 
     private static final String TAG = "UPDATE";
-    private static final boolean d = false;
 
     private RelativeLayout openRL;
     private RelativeLayout detectionRL;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/Ethernet.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/Ethernet.java
@@ -23,11 +23,6 @@ import com.jacky.launcher.R;
 
 public class Ethernet extends Activity {
 
-    private static final String TAG = "UPDATE";
-    private static final boolean d = false;
-
-    private ImageButton btnUpdate;
-
     private TextView tip;
 
     private BroadcastReceiver mConnReceiver = new BroadcastReceiver() {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/LocalServiceFragment.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/LocalServiceFragment.java
@@ -17,7 +17,6 @@ import java.util.List;
 public class LocalServiceFragment extends BaseFragment implements View.OnClickListener {
 
     private Context context;
-    private List<ContentValues> datas;
 
     private ImageButton tour;
     private ImageButton tv;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppAutoRun.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppAutoRun.java
@@ -25,8 +25,6 @@ import java.util.List;
 
 public class AppAutoRun extends Activity implements View.OnClickListener {
 
-    private static final String TAG = "UPDATE";
-    private static final boolean d = false;
     private ListView listView;
     private AppAutoRunAdapter adapter;
     private List<AppBean> mAppList;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppFragment.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppFragment.java
@@ -29,8 +29,6 @@ public class AppFragment extends BaseFragment {
     private int mPagerCount = -1;//一共的页数
     private List<AllApp> mPagerListAllApp = new ArrayList<>();
     private ViewPager mViewPager = null;
-    private static final String TAG = "AppFragment";
-    private static final boolean d = false;
     private TextView pointer = null;
     private Rotate3dAnimation rotation;
     private Receiver receiver;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppUninstall.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppUninstall.java
@@ -28,8 +28,6 @@ import java.util.List;
  */
 public class AppUninstall extends Activity implements View.OnClickListener {
 
-    private static final String TAG = "UPDATE";
-    private static final boolean d = false;
     private ListView listView;
     private AppUninstallAdapter adapter;
     private List<AppBean> mAppList;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/app/GetAppList.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/app/GetAppList.java
@@ -18,8 +18,6 @@ public class GetAppList {
 
     private Context mContext;
 
-    private static final String TAG = "GetAppList";
-
     public GetAppList(Context context) {
         mContext = context;
     }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingCustom.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingCustom.java
@@ -21,9 +21,6 @@ import com.jacky.launcher.features.wifi.WifiActivity;
  */
 public class SettingCustom extends Activity implements View.OnClickListener {
 
-    private static final String TAG = "UPDATE";
-    private static final boolean d = false;
-
     private TextView wifi;
     private TextView ethernet;
     private TextView bluetooth;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingFragment.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/setting/SettingFragment.java
@@ -40,11 +40,6 @@ public class SettingFragment extends BaseFragment implements
     private Intent JumpIntent;
     private Context context;
 
-    /**
-     * 用来存放
-     */
-    private List<ContentValues> datas;
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/NetWorkUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/NetWorkUtil.java
@@ -14,8 +14,6 @@ import java.lang.reflect.Method;
  * @since 2016.4.3
  */
 public class NetWorkUtil {
-    private final static String[] hexDigits = {"0", "1", "2", "3", "4", "5",
-            "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"};
     public static final int STATE_DISCONNECT = 0;
     public static final int STATE_WIFI = 1;
     public static final int STATE_MOBILE = 2;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
@@ -38,8 +38,6 @@ import java.util.regex.Pattern;
 
 @SuppressLint("DefaultLocale")
 public class Tools {
-
-    private static boolean d = true;
     private static String TAG = "Tools";
 
     private final static String[] hexDigits = {"0", "1", "2", "3", "4", "5",

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/AdapterView.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/AdapterView.java
@@ -34,9 +34,6 @@ abstract class AdapterView<T extends Adapter> extends android.widget.AdapterView
     private boolean mNeedSync = false;
     private int mSyncMode;
     private int mLayoutHeight;
-    private static final int SYNC_SELECTED_POSITION = 0;
-    private static final int SYNC_FIRST_POSITION = 1;
-    private static final int SYNC_MAX_DURATION_MILLIS = 100;
     private boolean mInLayout = false;
     private AdapterView.OnItemSelectedListener mOnItemSelectedListener;
     private AdapterView.OnItemClickListener mOnItemClickListener;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusedBasePositionManager.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusedBasePositionManager.java
@@ -18,7 +18,6 @@ public abstract class FocusedBasePositionManager {
     public static final int SCALED_FIXED_COEF = 1;
     public static final int SCALED_FIXED_X = 2;
     public static final int SCALED_FIXED_Y = 3;
-    private boolean DEBUG = true;
     private int mCurrentFrame = DEFAULT_FRAME;
     private int mFrameRate = DEFAULT_FRAME_RATE;
     private int mFocusFrameRate = 2;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusedRelativeLayout.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusedRelativeLayout.java
@@ -24,7 +24,6 @@ public class FocusedRelativeLayout extends RelativeLayout implements FocusedBase
     public static final String TAG = "FocusedRelativeLayout";
     public static final int HORIZONTAL_SINGEL = 1;
     public static final int HORIZONTAL_FULL = 2;
-    private static final int SCROLL_DURATION = 100;
     private long KEY_INTERVEL = 20L;
     private long mKeyTime = 0L;
     public int mIndex = -1;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/GameTitleView.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/GameTitleView.java
@@ -30,11 +30,8 @@ public class GameTitleView extends RelativeLayout {
     private View view;
     private Context context;
     private Typeface typeface;
-    private static final String TAG = "TitleView";
     private static final boolean d = false;
-    private ImageView imgWeather;
     private TextView tvTime, tvDate;
-    private Timer _timer;
     private ImageView imgNetWorkState;
 
     private Handler timeHandle = new Handler();

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/TitleView.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/TitleView.java
@@ -25,14 +25,11 @@ import java.util.Timer;
 
 public class TitleView extends RelativeLayout {
 
-    private static final String TAG = "TitleView";
     private RelativeLayout layout;
     private View view;
     private Context context;
     private Typeface typeface;
-    private ImageView imgWeather;
     private TextView tvTime, tvDate;
-    private Timer timer;
     private ImageView imgNetWorkState;
 
     private Handler timeHandle = new Handler();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1068 - Unused private fields should be removed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1068

Please let me know if you have any questions.

M-Ezzat