### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/data/VideoContract.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/data/VideoContract.java
@@ -104,9 +104,18 @@ public final class VideoContract {
         // The action intent for the result.
         public static final String COLUMN_ACTION = SearchManager.SUGGEST_COLUMN_INTENT_ACTION;
 
+        private VideoEntry() throws InstantiationException {
+            throw new InstantiationException("This class is not created for instantiation");
+        }
+
         // Returns the Uri referencing a video with the specified id.
         public static Uri buildVideoUri(long id) {
             return ContentUris.withAppendedId(CONTENT_URI, id);
         }
     }
+
+    private VideoContract() throws InstantiationException{
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
 }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/eliminateprocess/TextFormater.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/eliminateprocess/TextFormater.java
@@ -2,7 +2,12 @@ package com.jacky.launcher.features.eliminateprocess;
 
 import java.text.DecimalFormat;
 
-public class TextFormater {
+public final class TextFormater {
+
+    private TextFormater() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
     public static String longtoString(long size) {
         DecimalFormat format = new DecimalFormat("####.00");
         if (size < 1024) {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/ClearUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/ClearUtil.java
@@ -7,7 +7,12 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import java.io.File;
 import java.io.FileInputStream;
 
-public class ClearUtil {
+public final class ClearUtil {
+
+    private ClearUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
     public static boolean TakeIsInstallApk(String abPath, Context context) {
         PackageManager pm = context.getPackageManager();
         try {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/NetWorkUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/NetWorkUtil.java
@@ -13,7 +13,7 @@ import java.lang.reflect.Method;
  * @version 1.0
  * @since 2016.4.3
  */
-public class NetWorkUtil {
+public final class NetWorkUtil {
     public static final int STATE_DISCONNECT = 0;
     public static final int STATE_WIFI = 1;
     public static final int STATE_MOBILE = 2;
@@ -23,6 +23,10 @@ public class NetWorkUtil {
     public static final int WIFI_AP_STATE_ENABLING = 12;
     public static final int WIFI_AP_STATE_ENABLED = 13;
     public static final int WIFI_AP_STATE_FAILED = 14;
+
+    private NetWorkUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     private static int getWifiApState(Context mContext) {
         WifiManager wifiManager = (WifiManager) mContext

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/ReadFileUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/ReadFileUtil.java
@@ -9,7 +9,12 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 
-public class ReadFileUtil {
+public final class ReadFileUtil {
+
+    private ReadFileUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
     public static byte[] ReadFileFromURL(String url, NetworkSpeedInfo info) {
         int fileLenth = 0;
         long startTime = 0;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
@@ -37,8 +37,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @SuppressLint("DefaultLocale")
-public class Tools {
+public final class Tools {
     private static String TAG = "Tools";
+
+    private Tools() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiaation");
+    }
 
     private final static String[] hexDigits = {"0", "1", "2", "3", "4", "5",
             "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"};

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/TimeUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/TimeUtil.java
@@ -6,7 +6,11 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-public class TimeUtil {
+public final class TimeUtil {
+
+    private TimeUtil() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static String getTime() {
         String date = getFormattedDate();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat