### PR TITLE
squid:S881 - Increment (++) and decrement (--) operators should not b…

### DIFF
--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/PlaybackOverlayFragment.java
@@ -593,7 +593,8 @@ public class PlaybackOverlayFragment
         public void onPlayFromMediaId(String mediaId, Bundle extras) {
             Bundle args = new Bundle();
             args.putString(VideoContract.VideoEntry._ID, mediaId);
-            getLoaderManager().initLoader(mSpecificVideoLoaderId++, args, mCallbacks);
+            getLoaderManager().initLoader(mSpecificVideoLoaderId, args, mCallbacks);
+            mSpecificVideoLoaderId++;
         }
 
         @Override
@@ -607,7 +608,8 @@ public class PlaybackOverlayFragment
             Bundle bundle = new Bundle();
             bundle.putBoolean(AUTO_PLAY, true);
 
-            int nextIndex = ++mQueueIndex;
+            mQueueIndex++;
+            int nextIndex = mQueueIndex;
             if (nextIndex < mQueue.size()) {
                 MediaSession.QueueItem item = mQueue.get(nextIndex);
                 String mediaId = item.getDescription().getMediaId();
@@ -627,7 +629,8 @@ public class PlaybackOverlayFragment
             Bundle bundle = new Bundle();
             bundle.putBoolean(AUTO_PLAY, true);
 
-            int prevIndex = --mQueueIndex;
+            mQueueIndex--;
+            int prevIndex = mQueueIndex;
             if (prevIndex >= 0) {
                 MediaSession.QueueItem item = mQueue.get(prevIndex);
                 String mediaId = item.getDescription().getMediaId();

--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/SearchFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/SearchFragment.java
@@ -166,7 +166,8 @@ public class SearchFragment extends android.support.v17.leanback.app.SearchFragm
     private void loadQuery(String query) {
         if (!TextUtils.isEmpty(query) && !query.equals("nil")) {
             mQuery = query;
-            getLoaderManager().initLoader(mSearchLoaderId++, null, this);
+            getLoaderManager().initLoader(mSearchLoaderId, null, this);
+            mSearchLoaderId++;
         }
     }
 

--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/VideoDetailsFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/VideoDetailsFragment.java
@@ -145,7 +145,8 @@ public class VideoDetailsFragment extends DetailsFragment
 
             Bundle args = new Bundle();
             args.putString(VideoContract.VideoEntry._ID, videoId);
-            getLoaderManager().initLoader(mGlobalSearchVideoId++, args, this);
+            getLoaderManager().initLoader(mGlobalSearchVideoId, args, this);
+            mGlobalSearchVideoId++;
             return true;
         }
         return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S881 - Increment (++) and decrement (--) operators should not be mixed with other operators in an expression

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S881

Please let me know if you have any questions.

M-Ezzat