### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/common/src/main/java/com/jacky/common/logger/LoggerPrinter.java
+++ b/common/src/main/java/com/jacky/common/logger/LoggerPrinter.java
@@ -2,6 +2,7 @@ package com.jacky.common.logger;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -215,7 +216,7 @@ final class LoggerPrinter implements Printer {
         logHeaderContent(logType, tag, methodCount);
 
         //get bytes of message with system's default charset (which is UTF-8 for Android)
-        byte[] bytes = message.getBytes();
+        byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
         int length = bytes.length;
         if (length <= CHUNK_SIZE) {
             if (methodCount > 0) {
@@ -231,7 +232,7 @@ final class LoggerPrinter implements Printer {
         for (int i = 0; i < length; i += CHUNK_SIZE) {
             int count = Math.min(length - i, CHUNK_SIZE);
             //create a new String with system's default charset (which is UTF-8 for Android)
-            logContent(logType, tag, new String(bytes, i, count));
+            logContent(logType, tag, new String(bytes, i, count, StandardCharsets.UTF_8));
         }
         logBottomBorder(logType, tag);
     }

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/eliminateprocess/EliminateMainActivity.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/eliminateprocess/EliminateMainActivity.java
@@ -25,7 +25,9 @@ import com.jacky.launcher.R;
 import com.jacky.launcher.model.TaskInfo;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.List;
 
@@ -169,11 +171,13 @@ public class EliminateMainActivity extends Activity {
         String[] arrayOfString;
         long initialMemory = 0;
         try {
-            FileReader fileReader = new FileReader(str1);
-            BufferedReader bufferedReader = new BufferedReader(fileReader, 8192);
+            FileInputStream fileInputStream = new FileInputStream(str1);
+            InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
+            BufferedReader bufferedReader = new BufferedReader(inputStreamReader, 8192);
             str2 = bufferedReader.readLine();
             arrayOfString = str2.split("\\s+");
             initialMemory = Integer.valueOf(arrayOfString[1]);
+            fileInputStream.close();
         } catch (Exception e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileUtils.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileUtils.java
@@ -20,6 +20,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -46,7 +47,7 @@ public class FileUtils {
         try {
             FileOutputStream fos = context.openFileOutput(fileName,
                     Context.MODE_PRIVATE);
-            fos.write(content.getBytes());
+            fos.write(content.getBytes(StandardCharsets.UTF_8));
 
             fos.close();
         } catch (Exception e) {
@@ -83,7 +84,7 @@ public class FileUtils {
 
             outStream.close();
             inStream.close();
-            return outStream.toString();
+            return outStream.toString("UTF-8");
         } catch (IOException e) {
 
             

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/ReadFileUtil.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/ReadFileUtil.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 public final class ReadFileUtil {
 
@@ -33,11 +34,11 @@ public final class ReadFileUtil {
             NetworkSpeedInfo.totalBytes = fileLenth;
             b = new byte[fileLenth];
             startTime = System.currentTimeMillis();
-            BufferedReader bufferReader = new BufferedReader(new InputStreamReader(mUrlConnection.getInputStream()));
+            BufferedReader bufferReader = new BufferedReader(new InputStreamReader(mUrlConnection.getInputStream(), StandardCharsets.UTF_8));
             String line;
             byte[] buffer;
             while (NetworkSpeedInfo.FILECANREAD && ((line = bufferReader.readLine()) != null) && fileLenth > NetworkSpeedInfo.FinishBytes) {
-                buffer = line.getBytes();
+                buffer = line.getBytes(StandardCharsets.UTF_8);
                 intervalTime = System.currentTimeMillis() - startTime;
                 NetworkSpeedInfo.FinishBytes = NetworkSpeedInfo.FinishBytes + buffer.length;
                 if (intervalTime == 0) {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -74,7 +75,7 @@ public final class Tools {
             resultString = new String(origin);
             MessageDigest md = MessageDigest.getInstance("MD5");
             resultString = byteArrayToHexString(md.digest(resultString
-                    .getBytes()));
+                    .getBytes(StandardCharsets.UTF_8)));
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -275,7 +276,7 @@ public final class Tools {
             Process p = Runtime.getRuntime().exec("ping -c 1 -w 100 " + ip);// ping3次
             // 读取ping的内容，可不加。
             InputStream input = p.getInputStream();
-            BufferedReader in = new BufferedReader(new InputStreamReader(input));
+            BufferedReader in = new BufferedReader(new InputStreamReader(input,StandardCharsets.UTF_8));
             StringBuffer stringBuffer = new StringBuffer();
             String content = "";
             while ((content = in.readLine()) != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat