### PR TITLE
Multiple quality improvements - squid:UselessParenthesesCheck, squid:…

### DIFF
--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/model/Video.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/model/Video.java
@@ -33,6 +33,18 @@ public final class Video implements Parcelable {
     public final String videoUrl;
     public final String studio;
 
+    public static final Creator<Video> CREATOR = new Creator<Video>() {
+        @Override
+        public Video createFromParcel(Parcel in) {
+            return new Video(in);
+        }
+
+        @Override
+        public Video[] newArray(int size) {
+            return new Video[size];
+        }
+    };
+
     private Video(
             final long id,
             final String category,
@@ -62,18 +74,6 @@ public final class Video implements Parcelable {
         videoUrl = in.readString();
         studio = in.readString();
     }
-
-    public static final Creator<Video> CREATOR = new Creator<Video>() {
-        @Override
-        public Video createFromParcel(Parcel in) {
-            return new Video(in);
-        }
-
-        @Override
-        public Video[] newArray(int size) {
-            return new Video[size];
-        }
-    };
 
     @Override
     public boolean equals(Object m) {

--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/MainFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/MainFragment.java
@@ -359,7 +359,7 @@ public class MainFragment extends BrowseFragment implements LoaderManager.Loader
                     getFragmentManager().beginTransaction().replace(R.id.main_frame, errorFragment)
                             .addToBackStack(null).commit();
                 } else {
-                    Toast.makeText(getActivity(), ((String) item), Toast.LENGTH_SHORT)
+                    Toast.makeText(getActivity(), (String) item, Toast.LENGTH_SHORT)
                             .show();
                 }
             }

--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/SearchFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/SearchFragment.java
@@ -224,7 +224,7 @@ public class SearchFragment extends android.support.v17.leanback.app.SearchFragm
                         VideoDetailsActivity.SHARED_ELEMENT_NAME).toBundle();
                 getActivity().startActivity(intent, bundle);
             } else {
-                Toast.makeText(getActivity(), ((String) item), Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), (String) item, Toast.LENGTH_SHORT).show();
             }
         }
     }

--- a/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/VideoDetailsFragment.java
+++ b/LeanbackLauncher/src/main/java/com/example/android/tvleanback/ui/VideoDetailsFragment.java
@@ -305,7 +305,7 @@ public class VideoDetailsFragment extends DetailsFragment
         @Override
         public void onBindViewHolder(Presenter.ViewHolder viewHolder, Object item) {
             DetailsOverviewRow row = (DetailsOverviewRow) item;
-            ImageView imageView = ((ImageView) viewHolder.view);
+            ImageView imageView = (ImageView) viewHolder.view;
             imageView.setImageDrawable(row.getImageDrawable());
             if (isBoundToImage((ViewHolder) viewHolder, row)) {
                 ViewHolder vh =

--- a/jackyLauncher/src/main/java/com/jacky/launcher/adapter/AppAdapter.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/adapter/AppAdapter.java
@@ -25,7 +25,7 @@ import java.util.Random;
  */
 public class AppAdapter extends BaseAdapter {
 
-    private List<AppBean> mAppBeanList = null;
+    private List<AppBean> mAppBeanList;
     private Context mContext;
     public Holder mHolder;
     private AppFragment mAppFragment;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppFragment.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/app/AppFragment.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class AppFragment extends BaseFragment {
 
     private MainActivity mParent;
-    private List<AppBean> mAppList = null;
+    private List<AppBean> mAppList;
     private Receiver receiver;
     private GridView mGridView;
     private AppAdapter mAdapter;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/indicator/TabButton.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/indicator/TabButton.java
@@ -22,6 +22,19 @@ public class TabButton extends RelativeLayout implements View.OnFocusChangeListe
     private OnTabButtonChangeListener mOnTabButtonChangeListener;
     private OnTabButtonClickListener mOnTabButtonClickListener;
 
+    public TabButton(Context context) {
+        super(context);
+    }
+
+    public TabButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.tabButton);
+        mTitle = typedArray.getString(R.styleable.tabButton_buttonTitle);
+        typedArray.recycle();
+        mContext = context;
+        initUI();
+    }
+
     public interface OnTabButtonChangeListener {
         void onTabButtonChange(View v);
     }
@@ -36,19 +49,6 @@ public class TabButton extends RelativeLayout implements View.OnFocusChangeListe
 
     public void setOnTabButtonClickListener(OnTabButtonClickListener OnTabButtonClickListener) {
         mOnTabButtonClickListener = OnTabButtonClickListener;
-    }
-
-    public TabButton(Context context) {
-        super(context);
-    }
-
-    public TabButton(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.tabButton);
-        mTitle = typedArray.getString(R.styleable.tabButton_buttonTitle);
-        typedArray.recycle();
-        mContext = context;
-        initUI();
     }
 
     private void initUI() {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/features/indicator/TabIndicator.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/features/indicator/TabIndicator.java
@@ -22,6 +22,18 @@ public class TabIndicator extends LinearLayout implements TabButton.OnTabButtonC
 
     private ArrayList<TabButton> mTabButtonList = new ArrayList<>();
 
+    public TabIndicator(Context context) {
+        super(context);
+        mContext = context;
+        initUI();
+    }
+
+    public TabIndicator(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mContext = context;
+        initUI();
+    }
+
     public interface onTabChangeListener {
         void onTabChange(int index);
     }
@@ -36,18 +48,6 @@ public class TabIndicator extends LinearLayout implements TabButton.OnTabButtonC
 
     public void setOnTabClickListener(onTabClickListener onTabClickListener) {
         mOnTabClickListener = onTabClickListener;
-    }
-
-    public TabIndicator(Context context) {
-        super(context);
-        mContext = context;
-        initUI();
-    }
-
-    public TabIndicator(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        mContext = context;
-        initUI();
     }
 
     private void initUI() {

--- a/jackyLauncher/src/main/java/com/jacky/launcher/model/ApplicationInfo.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/model/ApplicationInfo.java
@@ -76,7 +76,7 @@ public class ApplicationInfo {
     @Override
     public int hashCode() {
         int result;
-        result = (title != null ? title.hashCode() : 0);
+        result = title != null ? title.hashCode() : 0;
         final String name = intent.getComponent().getClassName();
         result = 31 * result + (name != null ? name.hashCode() : 0);
         return result;

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileUtils.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/FileUtils.java
@@ -337,7 +337,7 @@ public class FileUtils {
         } else {
             return -1;
         }
-        return (freeSpace);
+        return freeSpace;
     }
 
     /**

--- a/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/utils/Tools.java
@@ -41,12 +41,12 @@ import java.util.regex.Pattern;
 public final class Tools {
     private static String TAG = "Tools";
 
+    private final static String[] hexDigits = {"0", "1", "2", "3", "4", "5",
+            "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"};
+
     private Tools() throws InstantiationException {
         throw new InstantiationException("This class is not created for instantiaation");
     }
-
-    private final static String[] hexDigits = {"0", "1", "2", "3", "4", "5",
-            "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"};
 
     public static String byteArrayToHexString(byte[] b) {
         StringBuffer resultSb = new StringBuffer();
@@ -186,9 +186,9 @@ public final class Tools {
             Date endData = df.parse(endTime);
             long l = endData.getTime() - countDown - now.getTime();
             long day = l / (24 * 60 * 60 * 1000);
-            long hour = (l / (60 * 60 * 1000) - day * 24);
-            long min = ((l / (60 * 1000)) - day * 24 * 60 - hour * 60);
-            long s = (l / 1000 - day * 24 * 60 * 60 - hour * 60 * 60 - min * 60);
+            long hour = l / (60 * 60 * 1000) - day * 24;
+            long min = (l / (60 * 1000)) - day * 24 * 60 - hour * 60;
+            long s = l / 1000 - day * 24 * 60 * 60 - hour * 60 * 60 - min * 60;
             return "ʣ��" + day + "��" + hour + "Сʱ" + min + "��" + s + "��";
         } catch (ParseException e) {
             e.printStackTrace();

--- a/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusView.java
+++ b/jackyLauncher/src/main/java/com/jacky/launcher/views/FocusView.java
@@ -21,15 +21,15 @@ public class FocusView extends View implements AnimatorListener {
     protected String focusTag = "focus";
 
     protected View mAnchorView;
-    protected int mOffsetX = 0;
-    protected int mOffsetY = 0;
-    protected int mOffsetWidth = 0;
-    protected int mOffsetHeight = 0;
+    protected int mOffsetX;
+    protected int mOffsetY;
+    protected int mOffsetWidth;
+    protected int mOffsetHeight;
     protected int mDuration = 200;
 
     private ObjectAnimator mObjectAnimator;
-    private boolean mMoving = false;
-    private boolean mMargin = false;
+    private boolean mMoving;
+    private boolean mMargin;
     private MarginLayoutParams mLayoutParams;
     private Queue<View> mQueue = new LinkedList<>();
 
@@ -122,8 +122,8 @@ public class FocusView extends View implements AnimatorListener {
         int width = view.getWidth();
         int height = view.getHeight();
 
-        PropertyValuesHolder pvhX = PropertyValuesHolder.ofFloat("x", (location[0] - mOffsetX));
-        PropertyValuesHolder pvhY = PropertyValuesHolder.ofFloat("y", (location[1] - mOffsetY));
+        PropertyValuesHolder pvhX = PropertyValuesHolder.ofFloat("x", location[0] - mOffsetX);
+        PropertyValuesHolder pvhY = PropertyValuesHolder.ofFloat("y", location[1] - mOffsetY);
         PropertyValuesHolder pvhW = PropertyValuesHolder.ofFloat("width", getWidth(), width + mOffsetWidth);
         PropertyValuesHolder pvhH = PropertyValuesHolder.ofFloat("height", getHeight(), height + mOffsetHeight);
         mObjectAnimator = ObjectAnimator.ofPropertyValuesHolder(this, pvhW, pvhH, pvhX, pvhY);
@@ -156,8 +156,8 @@ public class FocusView extends View implements AnimatorListener {
         int width = view.getWidth();
         int height = view.getHeight();
 
-        PropertyValuesHolder pvhX = PropertyValuesHolder.ofFloat("xcoor", getX(), (location[0] - mOffsetX));
-        PropertyValuesHolder pvhY = PropertyValuesHolder.ofFloat("ycoor", getY(), (location[1] - mOffsetY));
+        PropertyValuesHolder pvhX = PropertyValuesHolder.ofFloat("xcoor", getX(), location[0] - mOffsetX);
+        PropertyValuesHolder pvhY = PropertyValuesHolder.ofFloat("ycoor", getY(), location[1] - mOffsetY);
         PropertyValuesHolder pvhW = PropertyValuesHolder.ofFloat("width", getWidth(), width + mOffsetWidth);
         PropertyValuesHolder pvhH = PropertyValuesHolder.ofFloat("height", getHeight(), height + mOffsetHeight);
         mObjectAnimator = ObjectAnimator.ofPropertyValuesHolder(this, pvhW, pvhH, pvhX, pvhY);

--- a/uikit/src/main/java/com/jacky/uikit/fragment/BaseFragment.java
+++ b/uikit/src/main/java/com/jacky/uikit/fragment/BaseFragment.java
@@ -12,6 +12,19 @@ public class BaseFragment extends Fragment {
 
     private View mCurrentView;
 
+    public View.OnFocusChangeListener mFocusChangeListener = new View.OnFocusChangeListener() {
+
+        @Override
+        public void onFocusChange(View v, boolean hasFocus) {
+            if (hasFocus) {
+                mCurrentView = v;
+                enlargeAnim(v);
+            } else {
+                reduceAnim(v);
+            }
+        }
+    };
+
     public View getCurrentView() {
         return mCurrentView;
     }
@@ -27,19 +40,6 @@ public class BaseFragment extends Fragment {
     public View.OnFocusChangeListener getFocusChangeListener() {
         return mFocusChangeListener;
     }
-
-    public View.OnFocusChangeListener mFocusChangeListener = new View.OnFocusChangeListener() {
-
-        @Override
-        public void onFocusChange(View v, boolean hasFocus) {
-            if (hasFocus) {
-                mCurrentView = v;
-                enlargeAnim(v);
-            } else {
-                reduceAnim(v);
-            }
-        }
-    };
 
     public void enlargeAnim(View v) {
         Animation a = android.view.animation.AnimationUtils.loadAnimation(v.getContext(), R.anim.uikit_enlarge);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order
squid:S3052 - Fields should not be initialized to default values

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat