### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/Launcher-4.0/src/main/java/com/jacky/launcher/features/eliminateprocess/EliminateMainActivity.java
+++ b/Launcher-4.0/src/main/java/com/jacky/launcher/features/eliminateprocess/EliminateMainActivity.java
@@ -74,8 +74,8 @@ public class EliminateMainActivity extends Activity {
                     startKill.setText("清理完成");
                     break;
                 case NEEDENT_CLEAR:
-                    percentnum = 0 + "";
-                    clearMemory = 0 + "";
+                    percentnum = String.valueOf(0);
+                    clearMemory = String.valueOf(0);
                     Toast.makeText(EliminateMainActivity.this, "当前不需要清理", Toast.LENGTH_LONG).show();
                     break;
                 case PERCENT_CHANGE:

--- a/Launcher-4.0/src/main/java/com/jacky/launcher/features/eliminateprocess/TextFormater.java
+++ b/Launcher-4.0/src/main/java/com/jacky/launcher/features/eliminateprocess/TextFormater.java
@@ -30,7 +30,7 @@ public final class TextFormater {
 
     public static String floattoString(float size) {
         if (size < 0) {
-            return 0 + "";
+            return String.valueOf(0);
         } else {
             return size + "MB";
         }

--- a/Launcher-4.0/src/main/java/com/jacky/launcher/features/garbageclear/GarbageClear.java
+++ b/Launcher-4.0/src/main/java/com/jacky/launcher/features/garbageclear/GarbageClear.java
@@ -225,7 +225,7 @@ public class GarbageClear extends Activity {
             //执行完毕  开始执行下一个任务
             if (result != null && taskNum != 0) {
                 tasklist.get(0).execute();
-                grbageSize.setText((int) ((float) fileGrbagesize / 1024 / 1024 / 2) + "");
+                grbageSize.setText(String.valueOf((int) ((float) fileGrbagesize / 1024 / 1024 / 2)));
                 taskNum--;
                 tasklist.remove(0);
                 if (progressbarNum < 100) {

--- a/Launcher-4.0/src/main/java/com/jacky/launcher/utils/WiFiAdmin.java
+++ b/Launcher-4.0/src/main/java/com/jacky/launcher/utils/WiFiAdmin.java
@@ -112,7 +112,7 @@ public class WiFiAdmin {
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < mWifiList.size(); i++) {
             stringBuilder
-                    .append("Index_" + new Integer(i + 1).toString() + ":");
+                    .append("Index_" + (i + 1) + ":");
             // 将Scanresult转换成一个字符串包
             // 其中包括:BSSID SSID capabilities frequency level
             stringBuilder.append(mWifiList.get(i).toString());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for "String" conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat